### PR TITLE
Add workflow to auto-apply policies to custcodian

### DIFF
--- a/.github/workflows/custcodian.yaml
+++ b/.github/workflows/custcodian.yaml
@@ -1,0 +1,30 @@
+# DO NOT MERGE UP TO `mindersec/`, THIS FILE APPLIES POLICY FOR CUSTCODIAN
+# AND WILL NOT APPLY (MISSING PERMISSIONS) UPSTREAM.
+name: Apply Minder Profiles on Update
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  # id-token: write is needed to fetch a GitHub Actions token for other services
+  id-token: write
+  # contents: read is needed to checkout the current repo
+  contents: read
+
+jobs:
+  minder-config:
+    runs-on: ubuntu-latest
+    steps:
+    # TODO: enable pinning.
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - name: Apply Minder Config
+      uses: custcodian/minder-action@v1
+      with:
+        server: api.custcodian.dev
+        # This is the `minder-custcodian` project.
+        project: e6d46fac-6122-4949-a161-469f001aabb0
+        # Load the OSPS security baseline for the moment, will customize
+        # to other recommendations (and a directory list?) later.
+        directory: ./security-baseline


### PR DESCRIPTION
This is an attempt to use the new `custcodian/minder-action` IaC codepath.

I have already done the necessary `minder project role grant` command.